### PR TITLE
User icon without gravatar

### DIFF
--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -76,6 +76,14 @@ body {
         text-decoration: none;
     }
 
+    // カスタムフォント
+    .form-text {
+        font-weight: 400;
+        line-height: 1.5;
+        color: #212529;
+        text-align: left;
+    }
+
     // mediumの設定
 
     @media (min-width: 768px) {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,10 +34,11 @@ class UsersController < ApplicationController
 
   def update
     @user = User.find(params[:id])
+    @user.image.attach(user_params[:image]) if user_params[:image].present?
     info = user_params
     info[:email] = @user.email
     if @user.update(info)
-      flash[:success] = 'Profile updated'
+      flash[:success] = 'プロフィールを更新しました。'
       redirect_to @user
     else
       render 'edit'
@@ -74,7 +75,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :image)
   end
 
   # beforeアクション

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,6 +45,12 @@ class UsersController < ApplicationController
     end
   end
 
+  def gravatar_link
+    @user = User.find(params[:id])
+    @user.image.purge_later
+    redirect_to 'https://gravatar.com/emails'
+  end
+
   def destroy
     User.find(params[:id]).destroy
     flash[:success] = 'User deleted'

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,9 +1,14 @@
 module UsersHelper
 
-  # 引数で与えられたユーザーのGravatar画像を返す
-  def gravatar_for(user, add_class: '')
-    gravatar_id = Digest::MD5.hexdigest(user.email.downcase)
-    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}"
-    image_tag(gravatar_url, alt: user.name, class: "rounded-circle #{add_class}")
+  # 引数で与えられたユーザーのアイコン画像を返す
+  def icon_image(user, add_class: '')
+    if user.image.attached?
+      icon = user.display_icon
+    else
+      gravatar_id = Digest::MD5.hexdigest(user.email.downcase)
+      icon = "https://secure.gravatar.com/avatar/#{gravatar_id}"
+      # gravatar_url, alt: user.name, class: "rounded-circle #{add_class}"
+    end
+    image_tag(icon, alt: user.name, class: "rounded-circle #{add_class}")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,7 +89,7 @@ class User < ApplicationRecord
 
   # アイコン用の画像を返す
   def display_icon
-    image.variant(resize_to_limit: [300, 300])
+    image.variant(combine_options: { gravity: :center, resize: '300x300^', crop: '300x300+0+0' })
   end
 
   # ユーザーのステータスフィードを返す

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
+# rubocop:disable Metrics/ClassLength
 class User < ApplicationRecord
+  has_one_attached :image
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :active_relationships, class_name: 'Relationship',
@@ -30,6 +32,11 @@ class User < ApplicationRecord
 
   has_secure_password
   validates :password, presence: true, length: { minimum: 8 }, allow_nil: true
+
+  validates :image, content_type: { in: %w[image/jpeg image/gif image/png],
+                                    message: '規定のフォーマットにしてください。' },
+                    size: { less_than: 5.megabytes,
+                            message: '5MB以下にしてください' }
 
   # rspec modelテストでの表示用
   def inspect
@@ -78,6 +85,11 @@ class User < ApplicationRecord
   # パスワード再設定の期限が切れている場合はtrueを返す
   def password_reset_expired?
     reset_sent_at < 2.hours.ago
+  end
+
+  # アイコン用の画像を返す
+  def display_icon
+    image.variant(resize_to_limit: [300, 300])
   end
 
   # ユーザーのステータスフィードを返す
@@ -144,3 +156,5 @@ class User < ApplicationRecord
     self.activation_digest = User.digest(activation_token)
   end
 end
+
+# rubocop:enable Metrics/ClassLength

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,6 +1,6 @@
 <li id="comment-<%= comment.id %>" class="p-3 ls-none border-bottom">
     <div class="d-flex">
-        <%= gravatar_for comment.user, add_class: "icon-small" %>
+        <%= icon_image comment.user, add_class: "icon-small" %>
         <span class="font-ms my-auto ml-2 v-align-middle">
             <%= link_to comment.user.name, comment.user, class:"link" %>がコメント
         </span>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,7 +12,7 @@
         <div class="mr-2 dropdown">
             <% if logged_in? %>
             <div class="dropdown-toggle" data-toggle="dropdown" id="user-menu">
-                <%= gravatar_for current_user, add_class: "icon-medium" %>
+                <%= icon_image current_user, add_class: "icon-medium" %>
             </div>
             <div class="dropdown-menu">
                 <%= link_to "プロフィール", current_user, class: "dropdown-item" %>

--- a/app/views/posts/_post_base.html.erb
+++ b/app/views/posts/_post_base.html.erb
@@ -3,7 +3,7 @@
 <div class="d-flex justify-content-between col-12 p-0">
     <div class="flex-grow-1 p-0 <%= post.image.attached? ? "col-8" : "col-12" %>">
         <div class="d-flex">
-            <%= gravatar_for post.user, add_class: feed_flag ? "icon-small" : "icon-ms" %>
+            <%= icon_image post.user, add_class: feed_flag ? "icon-small" : "icon-ms" %>
             <span class="my-auto ml-2 v-align-middle <%= feed_flag ? "font-ms" : "font-medium" %>">
                 <%= link_to post.user.name, post.user, class:"link" %>が投稿
             </span>

--- a/app/views/users/_account_form.html.erb
+++ b/app/views/users/_account_form.html.erb
@@ -20,6 +20,24 @@
     <%= f.password_field :password_confirmation, class: "form-control", placeholder: "Password" %>
 </div>
 
+<% if icon_edit %>
+<h2 class="form-text font-medium">プロフィールアイコン</h2>
+<div class="d-flex mb-3">π¨
+    <%= icon_image @user, add_class: 'icon-medium mx-3 align-self-center' %>
+    <div class="form-group m-0">
+        <%= f.label :image, "写真を直接アップロード", class: "font-ms" %>
+        <%= f.file_field :image, accept: "image/jpeg,image/gif,image/png", class: "form-control-file" %>
+    </div>
+    <div class="mx-2 align-self-center">or</div>
+    <div class="gravatar_edit">
+        <h3 class='form-text font-ms'>Gravatorで設定する</h3>
+        <a href="https://gravatar.com/emails" target="_blank" rel="noopener">
+            Gravatorへ移動
+        </a>
+    </div>
+</div>
+<% end %>
+
 <%= f.submit submit_button, class: "btn btn-primary btn-block" %>
 
 <% end %>

--- a/app/views/users/_account_form.html.erb
+++ b/app/views/users/_account_form.html.erb
@@ -22,18 +22,23 @@
 
 <% if icon_edit %>
 <h2 class="form-text font-medium">プロフィールアイコン</h2>
-<div class="d-flex mb-3">π¨
-    <%= icon_image @user, add_class: 'icon-medium mx-3 align-self-center' %>
-    <div class="form-group m-0">
-        <%= f.label :image, "写真を直接アップロード", class: "font-ms" %>
-        <%= f.file_field :image, accept: "image/jpeg,image/gif,image/png", class: "form-control-file" %>
+<div class="d-flex mb-3 align-items-center">
+    <div class="w-25 mx-3 align-items-center d-flex flex-column">
+        <span class="font-ms">現在のアイコン</span><br>
+        <%= icon_image @user, add_class: 'icon-medium' %>
     </div>
-    <div class="mx-2 align-self-center">or</div>
-    <div class="gravatar_edit">
-        <h3 class='form-text font-ms'>Gravatorで設定する</h3>
-        <a href="https://gravatar.com/emails" target="_blank" rel="noopener">
-            Gravatorへ移動
-        </a>
+    <div>
+        <div class="form-group m-0">
+            <%= f.label :image, "写真を直接アップロード" %>
+            <%= f.file_field :image, accept: "image/jpeg,image/gif,image/png", class: "form-control-file" %>
+        </div>
+        <hr>
+        <div class="gravatar_edit">
+            <h3 class='form-text font-medium mt-3'>Gravatarで設定する</h3>
+            <%= link_to "Gravatarで設定", { controller: "users", action: "gravatar_link", id: @user.id },
+                                            method: :post, target: :_blank, rel: "noopener noreferrer", class: "ml-3" %>
+            <div class="font-small ml-3">(現在のアイコンは削除されます。)</div>
+        </div>
     </div>
 </div>
 <% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,5 +1,5 @@
 <li class="py-3 border-bottom border-dark">
-    <%= gravatar_for user, add_class: 'icon-medium' %>
+    <%= icon_image user, add_class: 'icon-medium' %>
     <%= link_to user.name, user_path(user) %>
     <% if logged_in? && current_user.admin? && !current_user?(user) %>
     | <%= link_to "削除", user, method: :delete, data: { confirm: "You sure?" } %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,9 +1,3 @@
 <% provide(:title, "アカウント設定") %>
 
-<%= render 'users/account_form', { submit_button: "更新", email_disable: true } %>
-
-<div class="gravatar_edit">
-    <%= gravatar_for @user, add_class: 'icon-medium' %>
-    <a href="https://gravatar.com/emails" target="_blank" rel="noopener">プロフィール画像の変更</a>
-
-</div>
+<%= render 'users/account_form', { submit_button: "更新", email_disable: true, icon_edit: true } %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,3 @@
 <% provide(:title, "新規登録") %>
 
-<%= render 'users/account_form', { submit_button: "登録", email_disable: false } %>
+<%= render 'users/account_form', { submit_button: "登録", email_disable: false, icon_edit: false  } %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
 <div class="p-0 mb-3 d-flex">
 
     <div class="col-3">
-        <%= gravatar_for @user, add_class: "icon-large" %>
+        <%= icon_image @user, add_class: "icon-large" %>
     </div>
     <div class="ml-3 col-9">
         <div class="d-flex justify-content-between align-items-center mb-2">

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -2,7 +2,7 @@
 <div class="p-0 mb-3 d-flex">
 
     <div class="col-3">
-        <%= gravatar_for @user, add_class: "icon-big" %>
+        <%= icon_image @user, add_class: "icon-big" %>
     </div>
     <div class="ml-3 col-9">
         <div class="d-flex justify-content-between align-items-center mb-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :users do
     member do
       get :following, :followers, :liked_posts
+      post :gravatar_link
     end
   end
   resources :account_activations, only: %i[edit]


### PR DESCRIPTION
gravatarに登録しなくても、直接アイコン画像をアップロードできるように改良しました。
 - UserHelperにアイコン画像表示用のメソッドを追加
 - アカウント編集画面で、アイコン画像をアップロードできるように変更
 - users#gravatar_linkを定義して、アイコン用画像を消したあとに、gravatarに飛ぶように変更